### PR TITLE
refactor: Improved the keymap for the navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ luac.out
 
 
 plugin/packer_compiled.lua
+.luarc.json

--- a/lua/tpAtalas/core/autocmd.lua
+++ b/lua/tpAtalas/core/autocmd.lua
@@ -4,6 +4,8 @@
 -- vim.cmd([[autocmd BufRead,BufNewFile * setlocal spell spelllang=en spelloptions=camel spellsuggest=best,5]])
 -- vim.cmd([[autocmd BufRead,BufNewFile * highlight SpellBad ctermfg=009 ctermbg=011 guifg=#e0def4 guibg=#403d52]])
 
-
 -- conditional colorcolumn
 vim.cmd([[autocmd BufRead,BufNewFile COMMIT_EDITMSG set colorcolumn=63,72,80]])
+
+-- conditional textwidth and wrap text
+vim.cmd([[autocmd BufRead,BufNewFile *.md set textwidth=80 wrap=true]])

--- a/lua/tpAtalas/core/keymaps.lua
+++ b/lua/tpAtalas/core/keymaps.lua
@@ -1,11 +1,11 @@
 local keymap = vim.keymap -- for conciseness
-
 local noremap = { noremap = true }
 
 -- set leader key to space
 keymap.set("", "<Space>", "<Nop>", { noremap = true, silent = true })
 vim.g.maplocalleader = " "
 vim.g.mapleader = " "
+vim.g.VM_default_mappings = 0 -- disable the visual-multi default key mapping
 
 -- Modes
 --   normal_mode = "n",
@@ -34,6 +34,9 @@ keymap.set("i", "<c-d><c-d>", "<ESC>dawi", noremap)
 -- keymap.set("i", "<leader>dd", "<ESC>ddi")
 keymap.set("n", "<leader>DD", ":%d<CR>", noremap)
 
+-- formatting
+keymap.set("n", "<leader>fma", "gggqG", noremap)
+
 -- Exiting
 keymap.set("n", "QQ", ":q!<CR>", noremap)
 keymap.set("n", "qq", ":q<CR>")
@@ -42,8 +45,14 @@ keymap.set("n", "qq", ":q<CR>")
 keymap.set("n", "<leader>ra", ":%s/<c-r><c-w>/", noremap) -- Search and replace the word under current
 --cursor
 keymap.set("n", "<leader>rr", "*#ciw", noremap) -- Search all same words and replace current worrd under cursor
--- keymap.set("n", "<leader><space>", ":noh<CR>") -- Clear Search Hightlight -- currently turned off
+-- keymap.set("n", "<leader><space>", ":noh<CR>") -- Clear Search Highlight -- currently turned off
 -- from setting
+
+-- Navigation
+keymap.set("n", "<s-up>", "<S-{>", noremap) -- jump paragraph up
+keymap.set("n", "<s-down>", "<S-}>", noremap) -- jump paragraph down
+keymap.set("n", "<s-right>", "w", noremap) -- jump paragraph down
+keymap.set("n", "<s-left>", "b", noremap) -- jump paragraph down
 
 -- Save
 keymap.set("n", "SS", ":w<CR>", noremap)
@@ -100,7 +109,7 @@ keymap.set("n", "<leader>tgs", "<cmd>Telescope git_status<CR>") -- list current 
 keymap.set("n", "<leader>lsr", ":LspRestart<CR>") -- mapping to restart lsp if necessary
 
 -- markdown preview
-keymap.set("n", "<leader>mpo", ":MarkdownPreview<CR>", noremap) -- start markdown preview open
+-- keymap.set("n", "<leader>mpo", ":MarkdownPreview<CR>", noremap) -- start markdown preview open
 keymap.set("n", "<leader>mps", ":MarkdownPreviewStop<CR>", noremap) -- stop markdown preview stop
 
 -- markdown toc

--- a/lua/tpAtalas/core/options.lua
+++ b/lua/tpAtalas/core/options.lua
@@ -9,6 +9,7 @@ opt.autoindent = true -- copy indent from current line when starting new one
 opt.colorcolumn = "80"
 opt.textwidth = 0
 opt.linebreak = true
+opt.breakindent = true
 opt.signcolumn = "yes" -- show sign column so that text doesn't shift
 opt.wrap = false
 opt.ignorecase = true -- ignore case when searching

--- a/lua/tpAtalas/plugins-setup.lua
+++ b/lua/tpAtalas/plugins-setup.lua
@@ -104,7 +104,7 @@ return packer.startup(function(use)
 	use({ "windwp/nvim-ts-autotag", after = "nvim-treesitter" }) -- autoclose tags
 
 	-- Indent Blankline
-	-- use("lukas-reineke/indent-blankline.nvim") -- adding unncessary characters when typing
+	-- use("lukas-reineke/indent-blankline.nvim") -- adding unnecessary characters when typing
 
 	-- Impatient improve the performance of lua module
 	use("lewis6991/impatient.nvim")


### PR DESCRIPTION
Added the better keymap for the jump through word and pargraph. To achieve this the default setup for the plugin `visual-multi` must be disabled due to its conflict.

New autocmd is added to limit the textwidth for the markdown files only.