### PR TITLE
refactor: Removed the `cmdheight` for the `lualine`

### DIFF
--- a/lua/tpAtalas/core/options.lua
+++ b/lua/tpAtalas/core/options.lua
@@ -28,7 +28,7 @@ opt.splitbelow = true -- split horizontal window to the bottom
 opt.hidden = true
 opt.iskeyword:append("-") -- consider string-string as whole word
 opt.backup = false -- creates a backup file
-opt.cmdheight = 2 -- more space in the neovim command line for displaying messages
+opt.cmdheight = 0 -- more space in the neovim command line for displaying messages
 opt.conceallevel = 0 -- so that `` is visible in markdown files
 -- opt.fileencoding = "utr-8" -- the encoding written to a file
 opt.mouse = "a" -- allow the mouse to be used in neovim

--- a/lua/tpAtalas/plugins/lualine.lua
+++ b/lua/tpAtalas/plugins/lualine.lua
@@ -34,7 +34,7 @@ lualine.setup({
 	options = {
 		icons_enabled = true,
 		theme = lualine_custom_theme,
-		-- component_separators = { left = "", right = "" },
+		component_separators = "",
 		-- section_separators = { left = "", right = "" },
 		disabled_filetypes = {
 			statusline = {},
@@ -53,7 +53,7 @@ lualine.setup({
 		lualine_a = { "mode" },
 		lualine_b = { "branch", "diff", "diagnostics" },
 		lualine_c = { "filename" },
-		lualine_x = { "encoding", "fileformat", "filetype" },
+		lualine_x = { "fileformat", "filetype" },
 		lualine_y = { "progress" },
 		lualine_z = { "location" },
 	},


### PR DESCRIPTION
`lualine` now supports the 0 height of `cmdheight`.