### PR TITLE
fix: Fixed the diagnostics not triggered in the workspace level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neovim initial setup
 
-![image](https://github.com/tpAtalas/tp-nvim-lua-config/blob/ba1ad1a63e91193f9071efd281b54810ea63b3dc/image.png?raw=true)
+![image](https://github.com/tpAtalas/tp-nvim-lua-config/blob/c6f214e0820f01bfc1bc38b3aad87170abeb7670/image.png?raw=true)
 
 ## Table of contents
 

--- a/lua/tpAtalas/core/keymaps.lua
+++ b/lua/tpAtalas/core/keymaps.lua
@@ -53,22 +53,22 @@ keymap.set('n', 'qq', ':q<CR>')
 
 -- Search and  Replace
 keymap.set('n', '<leader>ra', ':%s/<c-r><c-w>/', noremap) -- Search and replace the word under current
---cursor
-keymap.set('n', '<leader>rr', '*#ciw', noremap) -- Search all same words and replace current worrd under cursor
--- keymap.set("n", "<leader><space>", ":noh<CR>") -- Clear Search Highlight -- currently turned off
--- from setting
 
--- Navigation
+-- Navigation --
+-- paragraph navigate
 keymap.set('n', '<s-up>', '<S-{>', noremap) -- jump paragraph up
 keymap.set('n', '<s-down>', '<S-}>', noremap) -- jump paragraph down
 keymap.set('n', '<s-right>', 'w', noremap) -- jump paragraph down
 keymap.set('n', '<s-left>', 'b', noremap) -- jump paragraph down
-
+-- buffers navigate
+keymap.set('n', '<a-s-right>', ':bn<CR>', noremap) -- go to the next buffer
+keymap.set('n', '<a-s-left>', ':bp<CR>', noremap) -- go to the previous buffer
+keymap.set('n', '<c-q>', ':bd<CR>', noremap) -- go to the previous buffer
 
 -- Save
 keymap.set('n', 'SS', ':w<CR>', noremap) -- save
-keymap.set('n', '<leader><CR><CR>', ':source<CR>', noremap) -- reload
--- keymap.set('n', '<leader><CR><CR>', ':w<CR><cmd>lua ReloadConfig()<CR>', noremap)
+-- keymap.set('n', '<leader><CR><CR>', ':source<CR>', noremap) -- reload
+keymap.set('n', '<leader><CR><CR>', ':w<CR><cmd>lua ReloadConfig()<CR>', noremap)
 
 -- Delete single character without copying into register
 keymap.set('n', 'x', '"_x', noremap)
@@ -87,8 +87,8 @@ keymap.set('n', '<c-a-right>', ':vertical resize +5<CR>', noremap) -- increase s
 keymap.set('n', '<c-a-left>', ':vertical resize -5<CR>', noremap) -- decrease size vertically
 keymap.set('n', '<c-a-up>', ':horizontal resize +5<CR>', noremap) -- increase size horizontally
 keymap.set('n', '<c-a-down>', ':horizontal resize -5<CR>', noremap) -- decreise size horizontally
+keymap.set('n', '<c-space>', '<C-W>w', noremap) -- switch split window-- "workspace_diagnostics", "document_diagnostics", "quickfix", "lsp_references", "loclist"
 keymap.set('n', '<leader>=', '<C-W>=', noremap) -- reset resize: press <alt-=>
-keymap.set('n', '<leader>`', '<C-W>w', noremap) -- switch split window
 
 ----------------------
 -- Plugin Keybinds
@@ -105,7 +105,7 @@ keymap.set('n', '<leader>fec', ':NvimTreeCollapse<CR>', noremap) -- Collapses th
 
 -- telescope
 keymap.set('n', '<leader>ffo', '<cmd>Telescope find_files<CR>', noremap) -- find files within current working directory, respects .gitignore
-keymap.set('n', '<leader>ffs', '<cmd>Telescope live_grep<CR>', noremas) -- find string in current working directory as you type
+keymap.set('n', '<leader>ffs', '<cmd>Telescope live_grep<CR>', noremap) -- find string in current working directory as you type
 keymap.set('n', '<leader>ffc', '<cmd>Telescope grep_string<CR>', noremap) -- find string under cursor in current working directory
 keymap.set('n', '<leader>ffb', '<cmd>Telescope buffers<CR>', noremap) -- list open buffers in current neovim instance
 keymap.set('n', '<leader>ffh', '<cmd>Telescope help_tags<CR>', noremap) -- list available help tags
@@ -137,3 +137,6 @@ keymap.set('n', '<leader>cro', ':ColorizerToggle<CR>', noremap) -- toggle colori
 -- rest nvim
 keymap.set('n', '<leader>rno', '<Plug>RestNvim<CR>', noremap) -- run the request under the cursor
 keymap.set('n', '<leader>rnl', '<Plug>RestNvimLast<CR>', noremap) -- re-reun the last request
+
+--
+keymap.set('n', '<leader>dlo', '', noremap)

--- a/lua/tpAtalas/plugins/lsp/lspconfig.lua
+++ b/lua/tpAtalas/plugins/lsp/lspconfig.lua
@@ -5,10 +5,9 @@ if not lspconfig_status then
 	return
 end
 
-
-local typescript_setup, typescript = pcall(require, "typescript")
+local typescript_setup, typescript = pcall(require, 'typescript')
 if not typescript_setup then
-  return
+	return
 end
 
 local cmp_nvim_lsp_status, cmp_nvim_lsp = pcall(require, 'cmp_nvim_lsp')
@@ -35,7 +34,6 @@ local on_attach = function(client, bufnr)
 	keymap.set('n', 'K', '<cmd>Lspsaga hover_doc<CR>', opts) -- show documentation for what is under cursor
 	keymap.set('n', '<leader>o', '<cmd>LSoutlineToggle<CR>', opts) -- see outline on right hand side
 	keymap.set('n', '<space>wa', '<cmd>add_workspace_folder<CR>', opts)
-
 end
 
 -- used to enable autocompletion (assign to every lsp server config)
@@ -48,7 +46,7 @@ for type, icon in pairs(signs) do
 	vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = '' })
 end
 
--- For Reference: 
+-- For Reference:
 -- local function organize_imports()
 -- 	local params = {
 -- 		command = '_typescript.organizeImports',
@@ -69,9 +67,9 @@ lspconfig['html'].setup({
 -- Currently typescript.nvim plugin give better functionality
 typescript.setup({
   server = {
-    capabilities = capabilities,
-    on_attach = on_attach,
-  },
+		capabilities = capabilities,
+		on_attach = on_attach,
+	},
 })
 
 -- For Reference

--- a/lua/tpAtalas/plugins/lsp/null-ls.lua
+++ b/lua/tpAtalas/plugins/lsp/null-ls.lua
@@ -43,6 +43,7 @@ local source = {
 	--  to disable file types use
 	-- diagnostics.cspell,
 	-- codeactions.cspell,
+	diagnostics.tsc,
 	diagnostics.codespell,
 	formatting.codespell,
 	-- formatting.tidy,

--- a/lua/tpAtalas/plugins/lualine.lua
+++ b/lua/tpAtalas/plugins/lualine.lua
@@ -1,48 +1,71 @@
+-- https://github.com/nvim-lualine/lualine.nvim
 -- import lualine plugin safely
 local status, lualine = pcall(require, 'lualine')
 if not status then
 	return
 end
 
--- get lualine rose-pine theme
-local lualine_custom_theme = require('lualine.themes.powerline')
-
--- new colors for theme
-local new_colors = {
+-- https://rosepinetheme.com/palette
+local colors = {
 	foam = '#9ccfd8',
+	pine = '#31748f',
 	rose = '#ebbcba',
 	iris = '#c4a7e7',
 	gold = '#f6c177',
-	base = '#191724',
+	base = '#13111b',
+	love = '#eb6f92',
 	muted = '#6e6a86',
+	subtle = '#908caa',
+	text = '#e0def4',
+	overlay = '#26233a',
+	surface = '#1f1d2e',
+	blackhole = '#0a0a0a',
+	highlight_high = '#524f67',
+	highlight_med = '#403d52',
+	highlight_low = '#21202e',
 }
 
--- change nightlfy theme colors
-lualine_custom_theme.normal.a.bg = new_colors.foam
-lualine_custom_theme.insert.a.bg = new_colors.rose
-lualine_custom_theme.visual.a.bg = new_colors.iris
-lualine_custom_theme.command = {
-	a = {
-		gui = 'bold',
-		bg = new_colors.gold,
-		fg = new_colors.base,
+local custom_theme = {
+	normal = {
+		a = { gui = 'bold', fg = colors.surface, bg = colors.foam },
+		b = { fg = colors.text, bg = colors.highlight_med },
+		c = { fg = colors.subtle, bg = none },
+	},
+	insert = {
+		a = { gui = 'bold', fg = colors.surface, bg = colors.rose },
+		b = { fg = colors.base, bg = colors.foam,
+      },
+	},
+	visual = {
+		a = { gui = 'bold', fg = colors.surface, bg = colors.iris },
+	},
+	command = {
+		a = {
+			gui = 'bold',
+			bg = colors.gold,
+			fg = colors.base,
+		},
+	},
+	inactive = {
+		a = { fg = colors.subtle, bg = colors.highlight_low },
+		b = { fg = colors.muted, bg = colors.blackhole },
+		c = { fg = colors.subtle, bg = colors.base },
 	},
 }
 
--- configure lualine with modified theme
 lualine.setup({
 	options = {
 		icons_enabled = true,
-		theme = lualine_custom_theme,
-		component_separators = '',
-		-- section_separators = { left = "", right = "" },
+		theme = custom_theme,
+		component_separators = '|',
+		section_separators = { left = '', right = '' },
 		disabled_filetypes = {
 			statusline = {},
 			winbar = {},
 		},
 		ignore_focus = {},
 		always_divide_middle = true,
-		globalstatus = false,
+		globalstatus = true,
 		refresh = {
 			statusline = 1000,
 			tabline = 1000,
@@ -51,9 +74,30 @@ lualine.setup({
 	},
 	sections = {
 		lualine_a = { 'mode' },
-		lualine_b = { 'branch', 'diff', 'diagnostics' },
-		lualine_c = { 'filename' },
-		lualine_x = { 'fileformat', 'filetype' },
+		lualine_b = {
+      'branch',
+      {
+			'diff',
+      symbols = { added = ' ', modified = '柳', removed = ' ' },
+      diff_color = {
+          added = { fg = colors.foam },
+          modified = { fg = colors.gold },
+          removed = { fg = colors.love },
+        },
+      }
+		},
+		lualine_c = {
+			{
+				'diagnostics',
+				sources = { 'nvim_lsp', 'nvim_workspace_diagnostic', 'nvim_diagnostic' },
+				symbols = { error = ' ', warn = ' ', info = ' ' },
+				sections = { 'error', 'warn', 'info' },
+				colored = true,
+				update_in_insert = true,
+	  		always_visible = false,
+			},
+		},
+		lualine_x = { 'filetype' },
 		lualine_y = { 'progress' },
 		lualine_z = { 'location' },
 	},
@@ -65,8 +109,45 @@ lualine.setup({
 		lualine_y = {},
 		lualine_z = {},
 	},
-	tabline = {},
-	winbar = {},
+	tabline = {
+		lualine_a = {},
+		lualine_b = {
+			{
+				'buffers',
+				symbols = {
+					modified = ' ●',
+					alternate_file = '',
+					directory = '',
+				},
+			},
+		},
+		lualine_c = {},
+		lualine_x = {
+			{
+				'filename',
+				file_status = true,
+				newfile_status = false,
+				path = 1,
+				shorting_target = 40,
+				symbols = {
+					modified = '[+]',
+					readonly = '[-]',
+					unnamed = '',
+					newfile = '[New]',
+				},
+			},
+		},
+		lualine_y = {},
+		lualine_z = {},
+	},
+	winbar = {
+		lualine_a = {},
+		lualine_b = {},
+		lualine_c = {},
+		lualine_x = {},
+		lualine_y = {},
+		lualine_z = {},
+	},
 	inactive_winbar = {},
-	extensions = {},
+	extensions = { 'toggleterm', 'nvim-tree' },
 })

--- a/lua/tpAtalas/plugins/trouble.lua
+++ b/lua/tpAtalas/plugins/trouble.lua
@@ -6,9 +6,10 @@ end
 
 -- enable trouble
 trouble.setup({
-	height = 7,
+	height = 10,
 	auto_open = false,
 	auto_close = true,
+	mode = 'workspace_diagnostics',
 	use_diagnostic_signs = true,
 })
 


### PR DESCRIPTION
Because of the nature of language servers, the diagnostics have not been triggered at the workspace level but only at the local level. The diagnostics are only triggered if the buffer/file is open.

Parsing diagnostics from the Typescript compiler, `tsc`, within `null-ls` fixed this issue.