### PR TITLE
feat: Added the improved autocmd to auto highlight current word

### DIFF
--- a/lua/tpAtalas/core/autocmd.lua
+++ b/lua/tpAtalas/core/autocmd.lua
@@ -17,6 +17,14 @@ vim.cmd([[autocmd FileType markdown set textwidth=80 wrap]])
 vim.cmd([[autocmd TextChanged,InsertLeave *.* silent write]])
 
 -- highlight the match under cursor
--- for changing highlight color, go to colorScheme: IncSearch
-vim.cmd([[autocmd CursorHold,CursorHoldI * exe printf('match IncSearch /\V\<%s\>/', escape(expand('<cword>'), '/\'))]])
-
+vim.cmd([[
+  augroup AutoHighlight
+    function! HighlightCurrentWord(event)
+        set updatetime=500 " default updatetime=4000
+        exe printf('match IncSearch /\V\<%s\>/', escape(expand(a:event), '/\'))
+    endfunction    
+    autocmd!
+    autocmd CursorMovedI,CursorMoved * call HighlightCurrentWord('')
+    autocmd CursorHoldI,CursorHold * call HighlightCurrentWord('<cword>')
+  augroup end
+]])

--- a/lua/tpAtalas/core/options.lua
+++ b/lua/tpAtalas/core/options.lua
@@ -19,7 +19,6 @@ opt.hlsearch = false -- highlight all matches
 opt.incsearch = true
 opt.cursorline = true -- highlight the current cursor line
 opt.scrolloff = 10
-opt.updatetime = 300 -- cusorhold updatetime (default: 4000)
 opt.sidescrolloff = 10
 opt.termguicolors = true
 opt.background = 'dark' -- colorschemes that can be light or dark will be made dark


### PR DESCRIPTION
The new auto-highlight of the current word now disables the highlight whenever the cursor is moved in normal/insert mode. The updatetime is now configurable within the function of autocmd.