### PR TITLE
feat: Added the custom `OrganizeImports` for typescript

### DIFF
--- a/lua/tpAtalas/core/keymaps.lua
+++ b/lua/tpAtalas/core/keymaps.lua
@@ -39,8 +39,8 @@ keymap.set('n', '<leader>fma', 'gggqG', noremap) -- apply formatting if any
 -- formatting with typescript.nvim
 keymap.set('n', '<leader>fmf', ':TypescriptRenameFile<CR>') -- rename file and update imports
 keymap.set('n', '<leader>fmu', ':TypescriptRemoveUnused<CR>') -- remove unused variables
-keymap.set('n', '<leader>fmo', ':TypescriptOrganizeImports<CR>') -- Organize Import
 keymap.set('n', '<leader>fmm', ':TypescriptAddMissingImports<CR>') -- add missing imports
+keymap.set('n', '<leader>fmo', ':OrganizeImports<CR>') -- Organize Import (Custom)
 -- formatting move lines
 keymap.set('n', '<a-up>', ':move -2<CR>', noremap) -- move line upward
 keymap.set('n', '<a-down>', ':move +1<CR>', noremap) -- move line downward

--- a/lua/tpAtalas/plugins/lsp/lspconfig.lua
+++ b/lua/tpAtalas/plugins/lsp/lspconfig.lua
@@ -46,6 +46,15 @@ for type, icon in pairs(signs) do
 	vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = '' })
 end
 
+local function organize_imports()
+	local params = {
+		command = '_typescript.organizeImports',
+		arguments = { vim.api.nvim_buf_get_name(0) },
+		title = '',
+	}
+	vim.lsp.buf.execute_command(params)
+end
+
 -- Servers --
 -- html
 lspconfig['html'].setup({
@@ -62,6 +71,12 @@ typescript.setup({
 		init_options = {
 			preferences = {
 				disableSuggestions = true,
+			},
+		},
+		commands = {
+			OrganizeImports = {
+				organize_imports,
+				description = 'Organize Imports',
 			},
 		},
 	},


### PR DESCRIPTION
The custom function to organize imports is added to improve the organizing imports within the typescript file. The keymap for the organize imports is same as before: `<leader>fmo`.