### PR TITLE
perf: Improved the performance caused by `tsc`

### DIFF
--- a/lua/tpAtalas/core/autocmd.lua
+++ b/lua/tpAtalas/core/autocmd.lua
@@ -14,7 +14,14 @@ vim.cmd([[autocmd FileType lua nnoremap <buffer><leader><CR><CR> :w<CR><cmd>lua 
 vim.cmd([[autocmd FileType markdown set textwidth=80 wrap]])
 
 -- auto-save
-vim.cmd([[autocmd TextChanged,InsertLeave *.* silent write]])
+--
+-- NOTE:
+-- Write too often with autocmd will cause the high usage of CPU by TSC (typescript compiler) in null-ls. 
+-- By default, TSC runs on workspace whenever the new buffer is open or saved (write). `silent write` 
+-- every time TextChanged may cause performance issue
+--
+-- vim.cmd([[autocmd TextChanged,InsertLeave *.* silent write]])
+vim.cmd([[autocmd BufLeave,BufWinLeave,BufWipeout,BufUnload,BufDelete *.* silent write]])
 
 -- highlight the match under cursor
 vim.cmd([[

--- a/lua/tpAtalas/plugins/lsp/null-ls.lua
+++ b/lua/tpAtalas/plugins/lsp/null-ls.lua
@@ -63,4 +63,6 @@ null_ls.setup({
 	on_attach = on_attach,
 	debug = false,
 	fallback_severity = vim.diagnostic.severity.WARN,
+  update_in_insert = false,
+  debounce = 2000
 })


### PR DESCRIPTION
`tsc`, offered by null-ls, caused the performance issue when the usage is combined with `auto-save`. The `auto-save` was previously set to save whenever the textChanged or exited the insertMode. This triggers the `tsc` to compile and send diagnostics at the workspace level every time code has been updated or changed. Increasing the debounce rate and changing the save method fixed the performance issues.

It is still necessary to improve the `tsc` checking method in the near future.